### PR TITLE
Retain class inheritance

### DIFF
--- a/R/restore_labels.R
+++ b/R/restore_labels.R
@@ -59,7 +59,9 @@ restore_labels <- function(x, newLabels,
 
   # Ensure class consistency
   if (!inherits(x, "safeframe")) {
-    class(x) <- c("safeframe", class(x))
+    current_classes <- class(x)
+    df_index <- which(current_classes == "data.frame")
+    class(x) <- append(current_classes, "safeframe", after = df_index - 1)
   }
 
   x

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -11,6 +11,7 @@ lifecycle
 linelist
 messspeeds
 rlang
+struct
 tibble
 tidyselect
 tidyverse

--- a/tests/testthat/test-restore_labels.R
+++ b/tests/testthat/test-restore_labels.R
@@ -26,3 +26,21 @@ test_that("tests for restore_labels", {
   x$speed <- "test3"
   expect_equal(class(x), c("safeframe", "data.frame"))
 })
+
+test_that("retain class inheritance #56", {
+  
+  x <- make_safeframe(
+    cars,
+    speed = "Miles per hour"
+  )
+  class(x) <- c("linelist", class(x))
+  class(x)
+  #> [1] "linelist"   "safeframe"  "data.frame"
+  
+  y <- suppressWarnings(x[, 1])
+  #> Warning: The following labelled variables are lost:
+  #>  dist - NULL
+  class(y)
+  
+  expect_equal(class(x), class(y))
+})

--- a/tests/testthat/test-restore_labels.R
+++ b/tests/testthat/test-restore_labels.R
@@ -34,13 +34,18 @@ test_that("retain class inheritance #56", {
     speed = "Miles per hour"
   )
   class(x) <- c("linelist", class(x))
-  class(x)
-  #> [1] "linelist"   "safeframe"  "data.frame"
-  
   y <- suppressWarnings(x[, 1])
-  #> Warning: The following labelled variables are lost:
-  #>  dist - NULL
-  class(y)
   
   expect_equal(class(x), class(y))
+  
+  # For more complex class inheritance structure, such as a linelist tibble
+  x_tbl <- make_safeframe(
+    tibble::as_tibble(cars),
+    speed = "Miles per hour"
+  )
+  class(x_tbl) <- c("linelist", class(x_tbl))
+  
+  y_tbl <- suppressWarnings(x_tbl[, 1])
+  
+  expect_equal(class(x_tbl), class(y_tbl))
 })


### PR DESCRIPTION
Updates the `restore_labels` function to ensure "safeframe" gets added before data.frame as the relevant subclass, but does not gets prioritized over potential other internal classes.

Fixes #56. Includes the reproducible example from #56 as a test to ensure it stays fixed 😊
