### PR TITLE
Ensure dropped unlabelled columns do not throw warnings

### DIFF
--- a/R/square_bracket.R
+++ b/R/square_bracket.R
@@ -91,7 +91,7 @@
   }
 
   # Case 2
-  old_labels <- labels(x, show_null = TRUE)
+  old_labels <- labels(x, show_null = FALSE)
   out <- restore_labels(out, old_labels, lost_action)
 
   out

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -11,6 +11,7 @@ lifecycle
 linelist
 messspeeds
 rlang
+struct
 tibble
 tidyselect
 tidyverse

--- a/tests/testthat/test-square_bracket.R
+++ b/tests/testthat/test-square_bracket.R
@@ -160,3 +160,11 @@ test_that("$<- allows innocuous label modification", {
   attr(y, "label") <- "Miles per hour"
   expect_identical(x$speed, y)
 })
+
+test_that("no warnings when unlabelled columns are dropped - #55", {
+  x <- make_safeframe(cars,
+    speed = "Miles per hour"
+  )
+
+  expect_silent(x[, "speed"])
+})


### PR DESCRIPTION
This PR fixes the issue reported in #55, where unlabelled columns got a warning when dropped. 

Fixes #55.
