### PR TITLE
Update class retention in `[.safeframe` and `[<-.safeframe`

### DIFF
--- a/R/square_bracket.R
+++ b/R/square_bracket.R
@@ -92,8 +92,10 @@
 
   # Case 2
   old_tags <- tags(x)
+  old_classes <- class(x)
   out <- restore_tags(out, old_tags, lost_action)
-
+  class(out) <- old_classes
+  
   out
 }
 
@@ -105,7 +107,10 @@
   lost_action <- get_lost_tags_action()
   out <- NextMethod()
   old_tags <- tags(x)
+  old_classes <- class(x)
+  
   out <- restore_tags(out, old_tags, lost_action)
+  class(out) <- old_classes
 
   out
 }
@@ -122,6 +127,7 @@
   lost_tags(old_tags, new_tags, lost_action)
 
   class(x) <- setdiff(class(x), "safeframe")
+  
   x <- NextMethod()
 
   # Call restore_tags to restore the tags

--- a/tests/testthat/test-restore_tags.R
+++ b/tests/testthat/test-restore_tags.R
@@ -4,17 +4,17 @@ test_that("tests for restore_tags", {
   y <- drop_safeframe(x)
   z <- y
   names(z) <- c("titi", "toto")
-
+  
   # # Check error messages
   expect_error(
     restore_tags(z, tags(x)),
     "No matching tags provided."
   )
-
+  
   # Check functionality
   expect_identical(x, restore_tags(x, tags(x)))
   expect_identical(x, restore_tags(y, tags(x)))
-
+  
   # Classes are correct for different operator use
   expect_equal(class(x), c("safeframe", "data.frame"))
   y <- restore_tags(y, tags(x))
@@ -25,4 +25,25 @@ test_that("tests for restore_tags", {
   expect_equal(class(x), c("safeframe", "data.frame"))
   x$speed <- "test3"
   expect_equal(class(x), c("safeframe", "data.frame"))
+})
+
+test_that("retain class inheritance #56", {
+  x <- make_safeframe(
+    cars,
+    mph = "speed"
+  )
+  class(x) <- c("linelist", class(x))
+  y <- suppressWarnings(x[, 1])
+  
+  expect_equal(class(x), class(y))
+  
+  # For more complex class inheritance structure, such as a linelist tibble
+  x_tbl <- make_safeframe(
+    tibble::as_tibble(cars),
+    mph = "speed"
+  )
+  class(x_tbl) <- c("linelist", class(x_tbl))
+  y_tbl <- suppressWarnings(x_tbl[, 1])
+  
+  expect_equal(class(x_tbl), class(y_tbl))
 })


### PR DESCRIPTION
This PR updates the class retention in the subsetting of safeframe classes. This was initially attempted in #62, but did not function as expected. 

Given that the codebase changed since then (see #68), this PR is now opened and supercedes #62.

Fixes #56.