### PR TITLE
Implement class inheritance checking

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -5,10 +5,10 @@ on:
   pull_request:
     branches: [main, master]
     paths:
-      - '**.R'
-      - '**.Rmd'
-      - '**/.lintr'
-      - '**/.lintr.R'
+      - "**.R"
+      - "**.Rmd"
+      - "**/.lintr"
+      - "**/.lintr.R"
 
 name: lint-changed-files
 
@@ -34,6 +34,7 @@ jobs:
             any::gh
             any::lintr
             any::purrr
+            any::cyclocomp
             epiverse-trace/etdev
           needs: check
 

--- a/.lintr
+++ b/.lintr
@@ -2,7 +2,6 @@ linters: all_linters(
     packages = c("lintr", "etdev"),
     object_name_linter = NULL,
     implicit_integer_linter = NULL,
-    extraction_operator_linter = NULL,
     todo_comment_linter = NULL,
     library_call_linter = NULL,
     undesirable_function_linter(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ License: MIT + file LICENSE
 URL: https://epiverse-trace.github.io/safeframe/, https://github.com/epiverse-trace/safeframe
 BugReports: https://github.com/epiverse-trace/safeframe/issues
 Depends:
-    R (>= 3.1.0)
+    R (>= 4.0.0)
 Imports:
     checkmate,
     lifecycle,

--- a/R/validate_types.R
+++ b/R/validate_types.R
@@ -72,25 +72,33 @@ validate_types <- function(x, ...) {
 }
 
 #' Internal function
-#' 
 #' Custom implementation of checkmate's check_multi_class to ensure
 #' proper handling of multi-class situations as reported in #44.
-check_multi_class <- function (x, classes, null.ok = FALSE) 
-{
+#' @param x Object to check classes for
+#' @param classes Character vector of class names to check against
+#' @param null.ok Logical indicating whether NULL is allowed (default: FALSE)
+#' @noRd
+check_multi_class <- function(x, classes, null.ok = FALSE) {
   checkmate::qassert(classes, "S+")
   checkmate::qassert(null.ok, "B1")
-  if (is.null(x) && null.ok) 
+  if (is.null(x) && null.ok) {
     return(TRUE)
+  }
 
   # Get all classes including inherited ones
   obj_classes <- .class2(x)
 
   if (!any(classes %in% obj_classes)) {
-    cl = class(x)
-    return(sprintf("Must inherit from class '%s', but has class%s '%s'", 
-                   paste0(classes, collapse = "'/'"), if (length(cl) > 
-                                                          1L) "es" else "", paste0(cl, collapse = "','")))
+    cl <- class(x)
+    return(sprintf(
+      "Must inherit from class '%s', but has class%s '%s'",
+      paste(classes, collapse = "'/'"), if (length(cl) >
+        1L) {
+        "es"
+      } else {
+        ""
+      }, paste(cl, collapse = "','")
+    ))
   }
   return(TRUE)
 }
-

--- a/R/validate_types.R
+++ b/R/validate_types.R
@@ -47,7 +47,7 @@ validate_types <- function(x, ...) {
     vars_to_check,
     function(var) {
       allowed_types <- types[[var]]
-      checkmate::check_multi_class(
+      check_multi_class(
         x[[tags(x)[[var]]]],
         allowed_types,
         null.ok = TRUE
@@ -70,3 +70,27 @@ validate_types <- function(x, ...) {
 
   x
 }
+
+#' Internal function
+#' 
+#' Custom implementation of checkmate's check_multi_class to ensure
+#' proper handling of multi-class situations as reported in #44.
+check_multi_class <- function (x, classes, null.ok = FALSE) 
+{
+  checkmate::qassert(classes, "S+")
+  checkmate::qassert(null.ok, "B1")
+  if (is.null(x) && null.ok) 
+    return(TRUE)
+
+  # Get all classes including inherited ones
+  obj_classes <- .class2(x)
+
+  if (!any(classes %in% obj_classes)) {
+    cl = class(x)
+    return(sprintf("Must inherit from class '%s', but has class%s '%s'", 
+                   paste0(classes, collapse = "'/'"), if (length(cl) > 
+                                                          1L) "es" else "", paste0(cl, collapse = "','")))
+  }
+  return(TRUE)
+}
+

--- a/tests/testthat/test-validate_types.R
+++ b/tests/testthat/test-validate_types.R
@@ -47,7 +47,7 @@ test_that("Inherited classes are handled - #44", {
   x <- make_safeframe(x, bob = "y")
   expect_silent(validate_types(x, bob = "integer"))
   expect_silent(validate_types(x, bob = "numeric"))
-  
+
   y <- 1
   x <- data.frame(y)
   x <- make_safeframe(x, bob = "y")

--- a/tests/testthat/test-validate_types.R
+++ b/tests/testthat/test-validate_types.R
@@ -40,3 +40,17 @@ test_that("validate_types fails if types are provided for non-existent tags", {
     validate_types(x, distance = "numeric")
   )
 })
+
+test_that("Inherited classes are handled - #44", {
+  y <- 1L
+  x <- data.frame(y)
+  x <- make_safeframe(x, bob = "y")
+  expect_silent(validate_types(x, bob = "integer"))
+  expect_silent(validate_types(x, bob = "numeric"))
+  
+  y <- 1
+  x <- data.frame(y)
+  x <- make_safeframe(x, bob = "y")
+  expect_silent(validate_types(x, bob = "double"))
+  expect_silent(validate_types(x, bob = "numeric"))
+})


### PR DESCRIPTION
This PR updates the `validate_types` function to fix #44. **checkmate** uses a specific way to verify the classes in `check_multi_class` that I could not resolve, so I made a custom implementation that handles our cases.

If merged, fixes #44.
