### PR TITLE
Update arg `x -> .data` for `make_safeframe`

### DIFF
--- a/R/make_safeframe.R
+++ b/R/make_safeframe.R
@@ -5,7 +5,7 @@
 #' same `data.frame`, but `safeframe`-aware packages will then be able to
 #' automatically use tagged fields for further data cleaning and analysis.
 #'
-#' @param x a `data.frame` or a `tibble`
+#' @param .data a `data.frame` or a `tibble`
 #'
 #' @param ... <[`dynamic-dots`][rlang::dyn-dots]> A series of tags provided as
 #'   `tag_name = "column_name"`
@@ -44,16 +44,16 @@
 #' ## The output is strictly equivalent to the previous one
 #' identical(x, new_x)
 #'
-make_safeframe <- function(x,
+make_safeframe <- function(.data,
                            ...) {
   # assert inputs
-  checkmate::assert_data_frame(x, min.cols = 1)
-  assert_not_data_table(x)
+  checkmate::assert_data_frame(.data, min.cols = 1)
+  assert_not_data_table(.data)
 
   tags <- rlang::list2(...)
-  x <- tag_variables(x, tags)
+  .data <- tag_variables(.data, tags)
 
   # shape output and return object
-  class(x) <- c("safeframe", class(x))
-  x
+  class(.data) <- c("safeframe", class(.data))
+  .data
 }

--- a/R/set_tags.R
+++ b/R/set_tags.R
@@ -3,6 +3,7 @@
 #' This function changes the `tags` of a `safeframe` object, using the same
 #' syntax as the constructor [make_safeframe()].
 #'
+#' @param x a `data.frame` or a `tibble`, equivalent to parameter `.data` in [make_safeframe()]
 #' @inheritParams make_safeframe
 #'
 #' @seealso [make_safeframe()] to create a `safeframe` object

--- a/R/set_tags.R
+++ b/R/set_tags.R
@@ -3,7 +3,8 @@
 #' This function changes the `tags` of a `safeframe` object, using the same
 #' syntax as the constructor [make_safeframe()].
 #'
-#' @param x a `data.frame` or a `tibble`, equivalent to parameter `.data` in [make_safeframe()]
+#' @param x a `data.frame` or a `tibble`, equivalent to parameter `.data` in
+#'   [make_safeframe()]
 #' @inheritParams make_safeframe
 #'
 #' @seealso [make_safeframe()] to create a `safeframe` object

--- a/man/make_safeframe.Rd
+++ b/man/make_safeframe.Rd
@@ -4,10 +4,10 @@
 \alias{make_safeframe}
 \title{Create a safeframe from a data.frame}
 \usage{
-make_safeframe(x, ...)
+make_safeframe(.data, ...)
 }
 \arguments{
-\item{x}{a \code{data.frame} or a \code{tibble}}
+\item{.data}{a \code{data.frame} or a \code{tibble}}
 
 \item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> A series of tags provided as
 \code{tag_name = "column_name"}}

--- a/man/set_tags.Rd
+++ b/man/set_tags.Rd
@@ -7,7 +7,8 @@
 set_tags(x, ...)
 }
 \arguments{
-\item{x}{a \code{data.frame} or a \code{tibble}, equivalent to parameter \code{.data} in \code{\link[=make_safeframe]{make_safeframe()}}}
+\item{x}{a \code{data.frame} or a \code{tibble}, equivalent to parameter \code{.data} in
+\code{\link[=make_safeframe]{make_safeframe()}}}
 
 \item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> A series of tags provided as
 \code{tag_name = "column_name"}}

--- a/man/set_tags.Rd
+++ b/man/set_tags.Rd
@@ -7,7 +7,7 @@
 set_tags(x, ...)
 }
 \arguments{
-\item{x}{a \code{data.frame} or a \code{tibble}}
+\item{x}{a \code{data.frame} or a \code{tibble}, equivalent to parameter \code{.data} in \code{\link[=make_safeframe]{make_safeframe()}}}
 
 \item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> A series of tags provided as
 \code{tag_name = "column_name"}}

--- a/tests/testthat/test-make_safeframe.R
+++ b/tests/testthat/test-make_safeframe.R
@@ -55,3 +55,10 @@ test_that("alternative tagging functionality - position", {
   # Out of bounds position
   expect_error(make_safeframe(cars, outcome = 3))
 })
+
+test_that("can set x as label, #45", {
+  x <- data.frame(x = 1)
+  expect_no_error(make_safeframe(x,
+    x = "x"
+  ))
+})


### PR DESCRIPTION
This PR changes the argument name from `x` to `.data` for the main function to help prevent the error mentioned in #45.

This PR also adds a test with the reproducible example provided by @TimTaylor in the issue, to test this moving forward and prevent regression on this item in the future.

Fixes #45.
