### PR TITLE
Update `compat-dplyr`

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -13,6 +13,7 @@ linters: all_linters(
       )
     ),
     function_argument_linter = NULL,
+    one_call_pipe_linter = NULL,
     indentation_linter = NULL, # unstable as of lintr 3.1.0
     # Use minimum R declared in DESCRIPTION or fall back to current R version.
     # Install etdev package from https://github.com/epiverse-trace/etdev

--- a/tests/testthat/test-compat-dplyr.R
+++ b/tests/testthat/test-compat-dplyr.R
@@ -45,6 +45,14 @@ test_that("Compatibility with dplyr::slice()", {
 
 # Columns ----
 
+test_that("Compatibility with dplyr::count()", {
+  x %>% 
+    count(speed, dist) %>%
+    expect_s3_class("safeframe") %>%
+    tags() %>%
+    expect_identical(tags(x))
+})
+
 test_that("Compatibility with dplyr::transmute()", {
   x %>%
     dplyr::transmute(vitesse = speed) %>%

--- a/tests/testthat/test-compat-dplyr.R
+++ b/tests/testthat/test-compat-dplyr.R
@@ -47,7 +47,7 @@ test_that("Compatibility with dplyr::slice()", {
 
 test_that("Compatibility with dplyr::count()", {
   x %>% 
-    count(speed, dist) %>%
+    dplyr::count(speed, dist) %>%
     expect_s3_class("safeframe") %>%
     tags() %>%
     expect_identical(tags(x))

--- a/vignettes/compat-dplyr.Rmd
+++ b/vignettes/compat-dplyr.Rmd
@@ -94,7 +94,7 @@ During operations on columns, safeframe will:
 Count introduces new columns and retains tags for the existing columns:
 
 ```{r}
-x %>% 
+x %>%
   count(speed) %>%
   head()
 ```
@@ -176,8 +176,8 @@ Groups are not yet supported. Applying any verb operating on group to a safefram
 
 ```{r}
 # Does not retain tags
-x %>% 
-  group_by(speed) %>% 
+x %>%
+  group_by(speed) %>%
   head()
 ```
 

--- a/vignettes/compat-dplyr.Rmd
+++ b/vignettes/compat-dplyr.Rmd
@@ -89,6 +89,16 @@ During operations on columns, safeframe will:
 - stay invisible and conserve tags if no tagged column is affected by the operation
 - trigger `lost_tags_action()` if tagged columns are affected by the operation
 
+### `dplyr::count()` ✅ 
+
+Count introduces new columns and retains tags for the existing columns:
+
+```{r}
+x %>% 
+  count(speed) %>%
+  head()
+```
+
 ### `dplyr::mutate()` ✓ (partial)
 
 There is an incomplete compatibility with `dplyr::mutate()` in that simple renames without any actual modification of the column don't update the tags. In this scenario, users should rather use `dplyr::rename()`
@@ -163,6 +173,15 @@ x %>%
 ## Verbs operating on groups ✘
 
 Groups are not yet supported. Applying any verb operating on group to a safeframe will silently convert it back to a data.frame or tibble.
+
+```{r}
+# Does not retain tags
+x %>% 
+  group_by(speed) %>% 
+  head()
+```
+
+Please indicate if you would like to see this supported in a future release by commenting on the [GitHub issue about this](https://github.com/epiverse-trace/safeframe/issues/46).
 
 ## Verbs operating on data.frames
 


### PR DESCRIPTION
Based on #46, there are some minor updates to the compat dplyr vignette. It now includes tests for `dplyr::count` and indicates that groups is not supported, but we invite people to share if they have a need for this over in #46.