### PR TITLE
Use NextMethod() in print()

### DIFF
--- a/R/print.safeframe.R
+++ b/R/print.safeframe.R
@@ -31,7 +31,7 @@
 #' }
 print.safeframe <- function(x, ...) {
   cat("\n// safeframe object\n")
-  print(drop_safeframe(x))
+  NextMethod()
 
   # Extract names and values from tags(x)
   tag_values <- unlist(tags(x))


### PR DESCRIPTION
Any downsides to doing this?

With this change, linelist can also almost entirely rely on safeframe's print method by calling `NextMethod()`

Otherwise, linelist has to provide its own print method as:

- `drop_linelist()` also drops the safeframe class and we need to add the code to print tags in `print.linelist()`
- `NextMethod()` doesn't work as `drop_safeframe()` in `print.safeframe()` will return an object of class `c("linelist", "data.frame")` and call `print.linelist()` a second time.

This class nesting thing is a bit complicated so I don't know if it's clear in text. We can chat about this directly next week.
